### PR TITLE
Clippy fixes applied and FPS bug highlighted

### DIFF
--- a/src/engine/rendersystem/mod.rs
+++ b/src/engine/rendersystem/mod.rs
@@ -34,11 +34,11 @@ pub struct Model {
     //handle: VulkanModel
 }
 
-#[cfg(not(any(macos, ios, xbox)))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", xbox)))]
 mod vulkan;
 
 mod render_impl {
-    #[cfg(not(any(macos, ios, xbox)))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", xbox)))]
     pub use crate::engine::rendersystem::vulkan::*;
 }
 

--- a/src/platform/unix/video.rs
+++ b/src/platform/unix/video.rs
@@ -178,7 +178,7 @@ impl State {
         alloc_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> vk::SurfaceKHR {
         unsafe {
-            extensions::khr::XcbSurface::new(&entry, &instance)
+            extensions::khr::XcbSurface::new(entry, instance)
                 .create_xcb_surface(
                     &vk::XcbSurfaceCreateInfoKHR {
                         connection: self.connection.get_raw_conn() as *mut ffi::c_void,

--- a/src/platform/video.rs
+++ b/src/platform/video.rs
@@ -1,23 +1,23 @@
-#[cfg(all(unix, not(any(macos, ios))))]
+#[cfg(all(unix, not(any(target_os = "macos", targeto_os = "ios"))))]
 mod video_impl {
     use crate::platform::unix::video;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Mutex;
 
     static STATE: Mutex<Option<video::State>> = Mutex::new(None);
     pub fn init() {
         *STATE.lock().unwrap() = Some(video::State::init())
     }
     pub fn update() -> bool {
-        get_state!().update()
+        STATE.lock().unwrap().as_mut().unwrap().update()
     }
     pub fn shutdown() {
-        get_state!().shutdown()
+        STATE.lock().unwrap().as_mut().unwrap().shutdown()
     }
     pub fn get_size() -> (u32, u32) {
         STATE.lock().unwrap().as_ref().unwrap().get_size()
     }
     pub fn resized() -> bool {
-        get_state!().resized()
+        STATE.lock().unwrap().as_mut().unwrap().resized()
     }
     pub fn focused() -> bool {
         STATE.lock().unwrap().as_ref().unwrap().focused()
@@ -27,7 +27,12 @@ mod video_impl {
         instance: &ash::Instance,
         alloc_callbacks: Option<&ash::vk::AllocationCallbacks>,
     ) -> ash::vk::SurfaceKHR {
-        get_state!().create_vulkan_surface(entry, instance, alloc_callbacks)
+        STATE
+            .lock()
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .create_vulkan_surface(entry, instance, alloc_callbacks)
     }
 }
 


### PR DESCRIPTION
Applied several of "cargo clippy" 's suggested fixes, to neaten up the code and avoid redundancy.

There is a bug where the runtime quickly overflows because a variable wasn't being updated. I patched that, which revealed the fundamental bug: miliseconds aren't precise enough as the update function is being called many times per milisecond. I've commented the issue, but not tried to resolve it.